### PR TITLE
Dependency dirs is deprecated; use dirs-next

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Git
 ````
+Changed dependency `dirs` to `dirs-next`, as `dirs` is no longer maintained.
+
 Add "trim" subcommand which gets a --limit param and trims the cache down to that size limit.
 	While calculating the cache size, registry indices and installed binaries are skipped.
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -78,7 +78,7 @@ dependencies = [
  "cfg-if",
  "chrono",
  "clap",
- "dirs",
+ "dirs-next",
  "fs_extra",
  "git2",
  "home",
@@ -215,19 +215,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "524cbf6897b527295dff137cec09ecf3a05f4fddffd7dfcd1585403449e74198"
 
 [[package]]
-name = "dirs"
-version = "3.0.1"
+name = "dirs-next"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "142995ed02755914747cc6ca76fc7e4583cd18578746716d0508ea6ed558b9ff"
+checksum = "1cbcf9241d9e8d106295bd496bbe2e9cffd5fa098f2a8c9e2bbcbf09773c11a8"
 dependencies = [
- "dirs-sys",
+ "cfg-if",
+ "dirs-sys-next",
 ]
 
 [[package]]
-name = "dirs-sys"
-version = "0.3.5"
+name = "dirs-sys-next"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e93d7f5705de3e49895a2b5e0b8855a1c27f080192ae9c32a6432d50741a57a"
+checksum = "9c60f7b8a8953926148223260454befb50c751d3c50e1c178c4fd1ace4083c9a"
 dependencies = [
  "libc",
  "redox_users",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,7 +53,7 @@ cfg-if = { version = "0.1.10" } # if cfg(..)  { ...  }
 # https://github.com/chronotope/chrono
 chrono = { version = "0.4.11", optional = true } # compare dates etc
 
-# https://github.com/soc/dirs-rs
+# https://github.com/xdg-rs/dirs
 dirs-next = { version = "1.0.1", optional = true } # get cache dirs to look for sccache cache
 
 # https://github.com/XAMPPRocky/remove_dir_all

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ build = "src/build.rs"
 edition = "2018"
 
 [features]
-default = ["cargo_metadata", "chrono", "clap", "dirs", "git2", "humansize", "rayon", "regex", "rustc_tools_util", "walkdir"]
+default = ["cargo_metadata", "chrono", "clap", "dirs-next", "git2", "humansize", "rayon", "regex", "rustc_tools_util", "walkdir"]
 bench = [] # run benchmarks
 ci-autoclean = [] # minimal implementation that builds fast for CI
 offline_tests =  [] # only run tests that do not require internet connection
@@ -54,7 +54,7 @@ cfg-if = { version = "0.1.10" } # if cfg(..)  { ...  }
 chrono = { version = "0.4.11", optional = true } # compare dates etc
 
 # https://github.com/soc/dirs-rs
-dirs = { version = "3.0.1", optional = true } # get cache dirs to look for sccache cache
+dirs-next = { version = "1.0.1", optional = true } # get cache dirs to look for sccache cache
 
 # https://github.com/XAMPPRocky/remove_dir_all
 remove_dir_all = { version = "0.6.0" } # remove_dir_all on windows

--- a/src/commands/sccache.rs
+++ b/src/commands/sccache.rs
@@ -41,18 +41,14 @@ fn sccache_dir() -> Result<PathBuf, library::Error> {
         Ok(path)
     } else {
         // if SCCACHE_DIR variable is not present, get the cache dir from "dirs-next" crate
-        let mut cache_dir: Option<PathBuf> = dirs_next::cache_dir();
+        let mut cache_dir = dirs_next::cache_dir().ok_or(library::Error::NoSccacheDir)?;
 
-        if let Some(cache_dir) = cache_dir.as_mut() {
-            if cfg!(target_os = "macos") {
-                cache_dir.push("Mozilla.sccache");
-            } else {
-                cache_dir.push("sccache");
-            }
-            Ok(cache_dir.to_path_buf())
+        if cfg!(target_os = "macos") {
+            cache_dir.push("Mozilla.sccache");
         } else {
-            Err(library::Error::NoSccacheDir)
+            cache_dir.push("sccache");
         }
+        Ok(cache_dir)
     }
 }
 

--- a/src/commands/sccache.rs
+++ b/src/commands/sccache.rs
@@ -37,20 +37,18 @@ fn percentage_of_as_string(fraction: u64, total: u64) -> String {
 
 /// get the location of a local sccache path
 fn sccache_dir() -> Result<PathBuf, library::Error> {
-    if let Some(path) = env::var_os("SCCACHE_DIR").map(PathBuf::from) {
-        Ok(path)
-    } else {
-        // if SCCACHE_DIR variable is not present, get the cache dir from "dirs-next" crate
-        let cache_dir = dirs_next::cache_dir().ok_or(library::Error::NoSccacheDir)?;
+    env::var_os("SCCACHE_DIR")
+        .map(PathBuf::from)
+        .or_else(|| {
+            const CACHE_DIR_NAME: &str = if cfg!(target_os = "macos") {
+                "Mozilla.sccache"
+            } else {
+                "sccache"
+            };
 
-        const CACHE_DIR_NAME: &str = if cfg!(target_os = "macos") {
-            "Mozilla.sccache"
-        } else {
-            "sccache"
-        };
-
-        Ok(cache_dir.join(CACHE_DIR_NAME))
-    }
+            Some(dirs_next::cache_dir()?.join(CACHE_DIR_NAME))
+        })
+        .ok_or(library::Error::NoSccacheDir)
 }
 
 pub(crate) fn sccache_stats() -> Result<(), library::Error> {

--- a/src/commands/sccache.rs
+++ b/src/commands/sccache.rs
@@ -40,8 +40,8 @@ fn sccache_dir() -> Result<PathBuf, library::Error> {
     if let Some(path) = env::var_os("SCCACHE_DIR").map(PathBuf::from) {
         Ok(path)
     } else {
-        // if SCCACHE_DIR variable is not present, get the cache dir from "dirs" crate
-        let mut cache_dir: Option<PathBuf> = dirs::cache_dir();
+        // if SCCACHE_DIR variable is not present, get the cache dir from "dirs-next" crate
+        let mut cache_dir: Option<PathBuf> = dirs_next::cache_dir();
 
         if let Some(cache_dir) = cache_dir.as_mut() {
             if cfg!(target_os = "macos") {

--- a/src/commands/sccache.rs
+++ b/src/commands/sccache.rs
@@ -41,14 +41,15 @@ fn sccache_dir() -> Result<PathBuf, library::Error> {
         Ok(path)
     } else {
         // if SCCACHE_DIR variable is not present, get the cache dir from "dirs-next" crate
-        let mut cache_dir = dirs_next::cache_dir().ok_or(library::Error::NoSccacheDir)?;
+        let cache_dir = dirs_next::cache_dir().ok_or(library::Error::NoSccacheDir)?;
 
-        if cfg!(target_os = "macos") {
-            cache_dir.push("Mozilla.sccache");
+        const CACHE_DIR_NAME: &str = if cfg!(target_os = "macos") {
+            "Mozilla.sccache"
         } else {
-            cache_dir.push("sccache");
-        }
-        Ok(cache_dir)
+            "sccache"
+        };
+
+        Ok(cache_dir.join(CACHE_DIR_NAME))
     }
 }
 


### PR DESCRIPTION
Change dependency from `dirs` to `dirs-next` in manifest files and modify usage of `dirs` library to use `dirs-next` library.

[The reddit post](https://www.reddit.com/r/rust/comments/gli4pc/directoriesnext_dirsnext_the_new_home_for/?utm_source=share&utm_medium=web2x&context=3) about the change states that `dirs-next` is a drop in replacement. I could have just aliased `dirs-next` to `dirs` in Cargo.toml, but I actually changed the usage from `dirs` to `dirs-next`.

```diff
- let mut cache_dir: Option<PathBuf> = dirs::cache_dir();
+ let mut cache_dir: Option<PathBuf> = dirs_next::cache_dir();
```