### PR TITLE
implement cargo cache verify

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -159,6 +159,8 @@ jobs:
         run: cargo cache --info
       - name: run "cargo cache --list-dirs"
         run: cargo cache --list-dirs
+      - name: run "cargo cache verify"
+        run: cargo cache verify
       - name: run "cargo cache --keep-duplicate-crates 10 --dry-run"
         run: cargo cache --keep-duplicate-crates 10 --dry-run
       - name: run "cargo cache --keep-duplicate-crates 1  --dry-run"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 ## Git
 ```
+Add new subcommand "verify"
+cargo cache verify  tries to check corrupted (modified) crate sources
+The command looks into the .crate archive and compares the contained files with the extracted sources.
+If we find files that are not the same size in both places, the source is considered corrupted.
+cargo cache verify --clean-corrupted will automatically remove the corrupted sources. (supports --dry-run as well)
+
+
 Upgrade to from clap 2.33.3 to 3.0.0
 If you notice any change in behaviour that is not listed here, please let me know!
 Cli: removed "cargo cache query -h" for --human-readable because it was ambiguous with -h of --help.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,12 @@
 version = 3
 
 [[package]]
+name = "adler"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
+
+[[package]]
 name = "aho-corasick"
 version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -61,6 +67,7 @@ dependencies = [
  "chrono",
  "clap",
  "dirs-next",
+ "flate2",
  "fs_extra",
  "git2",
  "home",
@@ -71,6 +78,7 @@ dependencies = [
  "regex",
  "remove_dir_all 0.7.0",
  "rustc_tools_util",
+ "tar",
  "tempfile",
  "walkdir",
 ]
@@ -139,6 +147,15 @@ dependencies = [
  "termcolor",
  "terminal_size",
  "textwrap",
+]
+
+[[package]]
+name = "crc32fast"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "738c290dfaea84fc1ca15ad9c168d083b05a714e1efddd8edaab678dc28d2836"
+dependencies = [
+ "cfg-if",
 ]
 
 [[package]]
@@ -227,6 +244,30 @@ name = "either"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
+
+[[package]]
+name = "filetime"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "975ccf83d8d9d0d84682850a38c8169027be83368805971cc4f238c2b245bc98"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "winapi",
+]
+
+[[package]]
+name = "flate2"
+version = "1.0.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e6988e897c1c9c485f43b47a529cef42fde0547f9d8d41a7062518f1d8fc53f"
+dependencies = [
+ "cfg-if",
+ "crc32fast",
+ "libc",
+ "miniz_oxide",
+]
 
 [[package]]
 name = "form_urlencoded"
@@ -397,6 +438,16 @@ version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5aa361d4faea93603064a027415f07bd8e1d5c88c9fbf68bf56a285428fd79ce"
 dependencies = [
+ "autocfg",
+]
+
+[[package]]
+name = "miniz_oxide"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a92518e98c078586bc6c934028adcca4c92a53d6a958196de835170a01d84e4b"
+dependencies = [
+ "adler",
  "autocfg",
 ]
 
@@ -709,6 +760,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tar"
+version = "0.4.38"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b55807c0344e1e6c04d7c965f5289c39a8d94ae23ed5c0b57aabac549f871c6"
+dependencies = [
+ "filetime",
+ "libc",
+ "xattr",
+]
+
+[[package]]
 name = "tempfile"
 version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -862,3 +924,12 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "xattr"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "244c3741f4240ef46274860397c7c74e50eb23624996930e484c16679633a54c"
+dependencies = [
+ "libc",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,70 +1,71 @@
 [package]
-authors = ["Matthias Krüger <matthias.krueger@famsik.de>"]
-build = "src/build.rs"
-categories = ["command-line-utilities", "development-tools::cargo-plugins", "development-tools"]
-description = "Manage cargo cache ($CARGO_HOME or ~/.cargo/), show sizes and remove directories selectively"
-edition = "2021"
-homepage = "https://github.com/matthiaskrgr/cargo-cache"
-keywords = ["cargo", "cache", "cli", "manage", "cargo-home"]
-license = "MIT/Apache-2.0"
 name = "cargo-cache"
-readme = "README.md"
+version = "0.7.0"
+authors = ["Matthias Krüger <matthias.krueger@famsik.de>"]
+description = "Manage cargo cache ($CARGO_HOME or ~/.cargo/), show sizes and remove directories selectively"
+homepage = "https://github.com/matthiaskrgr/cargo-cache"
 repository = "https://github.com/matthiaskrgr/cargo-cache"
+license = "MIT/Apache-2.0"
+readme = "README.md"
+keywords = ["cargo", "cache", "cli", "manage", "cargo-home"]
+categories = ["command-line-utilities", "development-tools::cargo-plugins", "development-tools"]
+build = "src/build.rs"
+edition = "2021"
 resolver = "2"
 rust-version = "1.56"
-version = "0.7.0"
 
 [features]
+default = ["cargo_metadata", "chrono", "clap", "dirs-next", "git2", "humansize", "rayon", "regex", "rustc_tools_util", "walkdir", "tar", "flate2"]
 bench = [] # run benchmarks
 ci-autoclean = [] # minimal implementation that builds fast for CI
-default = ["cargo_metadata", "chrono", "clap", "dirs-next", "git2", "humansize", "rayon", "regex", "rustc_tools_util", "walkdir", "tar", "flate2"]
-offline_tests = [] # only run tests that do not require internet connection
+offline_tests =  [] # only run tests that do not require internet connection
 # some details: https://github.com/NixOS/nixpkgs/pull/77310
 [dependencies]
 # https://github.com/oli-obk/cargo_metadata
-cargo_metadata = {version = "0.14.1", optional = true}# get crate package name
+cargo_metadata = { version = "0.14.1", optional = true } # get crate package name
 
 # https://github.com/alexcrichton/cfg-if
-cfg-if = {version = "1.0.0"}# if cfg(..)  { ...  }
+cfg-if = { version = "1.0.0" } # if cfg(..)  { ...  }
 
 # https://github.com/chronotope/chrono
-chrono = {version = "0.4.19", optional = true}# compare dates etc
+chrono = { version = "0.4.19", optional = true } # compare dates etc
 
 # https://github.com/kbknapp/clap-rs
 clap = {version = "3.0.0-rc.7", features = ["wrap_help"], optional = true}# cmdline arg parsing
 
 # https://github.com/xdg-rs/dirs
-dirs-next = {version = "2.0.0", optional = true}# get cache dirs to look for sccache cache
+dirs-next = { version = "2.0.0", optional = true } # get cache dirs to look for sccache cache
 
 # https://github.com/rust-lang/flate2-rs
 flate2 = {version = "1.0.22", optional = true}# look into gzs
 
 # https://github.com/alexcrichton/git2-rs
-git2 = {version = "0.13.22", default-features = false, optional = true, features = ["vendored-libgit2"]}# check if repo is git repo
+git2 = { version = "0.13.22", default-features = false, optional = true, features = ["vendored-libgit2"] } # check if repo is git repo
 
 # https://github.com/brson/home
 home = "0.5.3" # get CARGO_HOME
 
 # https://github.com/LeopoldArkham/humansize
-humansize = {version = "1.1.0", optional = true}# convert digits of bytes to human readable size
+humansize = { version = "1.1.0", optional = true } # convert digits of bytes to human readable size
 
 # https://github.com/rayon-rs/rayon
-rayon = {version = "1.5.0", optional = true}# parallelize iterators
+rayon = { version = "1.5.0", optional = true } # parallelize iterators
 
 # https://github.com/rust-lang/regex
-regex = {version = "1.4.2", optional = true}# use regex for matching
+regex = { version = "1.4.2", optional = true } # use regex for matching
 
 # https://github.com/XAMPPRocky/remove_dir_all
-remove_dir_all = {version = "0.7.0"}# remove_dir_all on windows
+remove_dir_all = { version = "0.7.0" } # remove_dir_all on windows
 
 # https://github.com/rust-lang/rust-clippy/tree/master/rustc_tools_util
-rustc_tools_util = {version = "0.2.0", optional = true}# git version information
+rustc_tools_util = { version = "0.2.0", optional = true } # git version information
 
 # https://github.com/alexcrichton/tar-rs
-tar = {version = "0.4.38", optional = true}# extract tars
+tar = { version = "0.4.38", optional = true } # extract tars
 
 # https://github.com/BurntSushi/walkdir
-walkdir = {version = "2.3.1", optional = true}# walk content of directory/CARGO_HOME recursively
+walkdir = { version = "2.3.1", optional = true } # walk content of directory/CARGO_HOME recursively
+
 
 [dev-dependencies]
 # https://github.com/rhysd/path-slash
@@ -84,20 +85,20 @@ tempfile = "3.1.0" # create and rm temporary directories for tests
 rustc_tools_util = "0.2.0" # git version information
 
 [[bin]]
-bench = true
 name = "cargo-cache"
 path = "src/main.rs"
 test = true
+bench = true
 
 [badges]
 #travis-ci = { repository = "matthiaskrgr/cargo-cache", branch = "master" }
 
 [profile.release]
-codegen-units = 8
-incremental = true
-lto = "thin"
-
-[profile.bench]
+lto = true
 codegen-units = 1
 incremental = false
+
+[profile.bench]
 lto = true
+codegen-units = 1
+incremental = false

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ resolver = "2"
 rust-version = "1.56"
 
 [features]
-default = ["cargo_metadata", "chrono", "clap", "dirs-next", "git2", "humansize", "rayon", "regex", "rustc_tools_util", "walkdir"]
+default = ["cargo_metadata", "chrono", "clap", "dirs-next", "git2", "humansize", "rayon", "regex", "rustc_tools_util", "walkdir", "tar", "flate2"]
 bench = [] # run benchmarks
 ci-autoclean = [] # minimal implementation that builds fast for CI
 offline_tests =  [] # only run tests that do not require internet connection
@@ -35,6 +35,9 @@ clap = {version = "3.0.0-rc.7", features = ["wrap_help"], optional = true}# cmdl
 
 # https://github.com/xdg-rs/dirs
 dirs-next = { version = "2.0.0", optional = true } # get cache dirs to look for sccache cache
+
+# https://github.com/rust-lang/flate2-rs
+flate2 = {version = "1.0.22", optional = true}# look into gzs
 
 # https://github.com/alexcrichton/git2-rs
 git2 = { version = "0.13.22", default-features = false, optional = true, features = ["vendored-libgit2"] } # check if repo is git repo
@@ -56,6 +59,9 @@ remove_dir_all = { version = "0.7.0" } # remove_dir_all on windows
 
 # https://github.com/rust-lang/rust-clippy/tree/master/rustc_tools_util
 rustc_tools_util = { version = "0.2.0", optional = true } # git version information
+
+# https://github.com/alexcrichton/tar-rs
+tar = { version = "0.4.38", optional = true } # extract tars
 
 # https://github.com/BurntSushi/walkdir
 walkdir = { version = "2.3.1", optional = true } # walk content of directory/CARGO_HOME recursively

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,71 +1,70 @@
 [package]
-name = "cargo-cache"
-version = "0.7.0"
 authors = ["Matthias Krüger <matthias.krueger@famsik.de>"]
-description = "Manage cargo cache ($CARGO_HOME or ~/.cargo/), show sizes and remove directories selectively"
-homepage = "https://github.com/matthiaskrgr/cargo-cache"
-repository = "https://github.com/matthiaskrgr/cargo-cache"
-license = "MIT/Apache-2.0"
-readme = "README.md"
-keywords = ["cargo", "cache", "cli", "manage", "cargo-home"]
-categories = ["command-line-utilities", "development-tools::cargo-plugins", "development-tools"]
 build = "src/build.rs"
+categories = ["command-line-utilities", "development-tools::cargo-plugins", "development-tools"]
+description = "Manage cargo cache ($CARGO_HOME or ~/.cargo/), show sizes and remove directories selectively"
 edition = "2021"
+homepage = "https://github.com/matthiaskrgr/cargo-cache"
+keywords = ["cargo", "cache", "cli", "manage", "cargo-home"]
+license = "MIT/Apache-2.0"
+name = "cargo-cache"
+readme = "README.md"
+repository = "https://github.com/matthiaskrgr/cargo-cache"
 resolver = "2"
 rust-version = "1.56"
+version = "0.7.0"
 
 [features]
-default = ["cargo_metadata", "chrono", "clap", "dirs-next", "git2", "humansize", "rayon", "regex", "rustc_tools_util", "walkdir", "tar", "flate2"]
 bench = [] # run benchmarks
 ci-autoclean = [] # minimal implementation that builds fast for CI
-offline_tests =  [] # only run tests that do not require internet connection
+default = ["cargo_metadata", "chrono", "clap", "dirs-next", "git2", "humansize", "rayon", "regex", "rustc_tools_util", "walkdir", "tar", "flate2"]
+offline_tests = [] # only run tests that do not require internet connection
 # some details: https://github.com/NixOS/nixpkgs/pull/77310
 [dependencies]
 # https://github.com/oli-obk/cargo_metadata
-cargo_metadata = { version = "0.14.1", optional = true } # get crate package name
+cargo_metadata = {version = "0.14.1", optional = true}# get crate package name
 
 # https://github.com/alexcrichton/cfg-if
-cfg-if = { version = "1.0.0" } # if cfg(..)  { ...  }
+cfg-if = {version = "1.0.0"}# if cfg(..)  { ...  }
 
 # https://github.com/chronotope/chrono
-chrono = { version = "0.4.19", optional = true } # compare dates etc
+chrono = {version = "0.4.19", optional = true}# compare dates etc
 
 # https://github.com/kbknapp/clap-rs
 clap = {version = "3.0.0-rc.7", features = ["wrap_help"], optional = true}# cmdline arg parsing
 
 # https://github.com/xdg-rs/dirs
-dirs-next = { version = "2.0.0", optional = true } # get cache dirs to look for sccache cache
+dirs-next = {version = "2.0.0", optional = true}# get cache dirs to look for sccache cache
 
 # https://github.com/rust-lang/flate2-rs
 flate2 = {version = "1.0.22", optional = true}# look into gzs
 
 # https://github.com/alexcrichton/git2-rs
-git2 = { version = "0.13.22", default-features = false, optional = true, features = ["vendored-libgit2"] } # check if repo is git repo
+git2 = {version = "0.13.22", default-features = false, optional = true, features = ["vendored-libgit2"]}# check if repo is git repo
 
 # https://github.com/brson/home
 home = "0.5.3" # get CARGO_HOME
 
 # https://github.com/LeopoldArkham/humansize
-humansize = { version = "1.1.0", optional = true } # convert digits of bytes to human readable size
+humansize = {version = "1.1.0", optional = true}# convert digits of bytes to human readable size
 
 # https://github.com/rayon-rs/rayon
-rayon = { version = "1.5.0", optional = true } # parallelize iterators
+rayon = {version = "1.5.0", optional = true}# parallelize iterators
 
 # https://github.com/rust-lang/regex
-regex = { version = "1.4.2", optional = true } # use regex for matching
+regex = {version = "1.4.2", optional = true}# use regex for matching
 
 # https://github.com/XAMPPRocky/remove_dir_all
-remove_dir_all = { version = "0.7.0" } # remove_dir_all on windows
+remove_dir_all = {version = "0.7.0"}# remove_dir_all on windows
 
 # https://github.com/rust-lang/rust-clippy/tree/master/rustc_tools_util
-rustc_tools_util = { version = "0.2.0", optional = true } # git version information
+rustc_tools_util = {version = "0.2.0", optional = true}# git version information
 
 # https://github.com/alexcrichton/tar-rs
-tar = { version = "0.4.38", optional = true } # extract tars
+tar = {version = "0.4.38", optional = true}# extract tars
 
 # https://github.com/BurntSushi/walkdir
-walkdir = { version = "2.3.1", optional = true } # walk content of directory/CARGO_HOME recursively
-
+walkdir = {version = "2.3.1", optional = true}# walk content of directory/CARGO_HOME recursively
 
 [dev-dependencies]
 # https://github.com/rhysd/path-slash
@@ -85,20 +84,20 @@ tempfile = "3.1.0" # create and rm temporary directories for tests
 rustc_tools_util = "0.2.0" # git version information
 
 [[bin]]
+bench = true
 name = "cargo-cache"
 path = "src/main.rs"
 test = true
-bench = true
 
 [badges]
 #travis-ci = { repository = "matthiaskrgr/cargo-cache", branch = "master" }
 
 [profile.release]
-lto = true
-codegen-units = 1
-incremental = false
+codegen-units = 8
+incremental = true
+lto = "thin"
 
 [profile.bench]
-lto = true
 codegen-units = 1
 incremental = false
+lto = true

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Display information on the cargo cache (`~/.cargo/` or `$CARGO_HOME`). Optional 
 * builds and runs on `stable`, `beta` and `nightly` channel
 * purge cache entries not unused to build a specified crate (`cargo cache clean-unref`)
 * print size stats on a local sccache build cache  (`cargo cache sc`)
+* verify extracted crate sources (`cargo cache verify)
 
 #### Installation:
 ```cargo install cargo-cache```
@@ -83,6 +84,7 @@ SUBCOMMANDS:
     sccache        gather stats on a local sccache cache
     toolchain      print stats on installed toolchains
     trim           trim old items from the cache until maximum cache size limit is reached
+    verify         verify crate sources
 ````
 
 #### Show the largest items in the cargo home:

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -554,7 +554,8 @@ SUBCOMMANDS:
     sc             gather stats on a local sccache cache
     sccache        gather stats on a local sccache cache
     toolchain      print stats on installed toolchains
-    trim           trim old items from the cache until maximum cache size limit is reached\n",
+    trim           trim old items from the cache until maximum cache size limit is reached
+    verify         verify crate sources\n",
         );
         assert_eq!(help_desired, help_real);
     }
@@ -633,7 +634,8 @@ SUBCOMMANDS:
     sc             gather stats on a local sccache cache
     sccache        gather stats on a local sccache cache
     toolchain      print stats on installed toolchains
-    trim           trim old items from the cache until maximum cache size limit is reached\n",
+    trim           trim old items from the cache until maximum cache size limit is reached
+    verify         verify crate sources\n",
         );
 
         assert_eq!(help_desired, help_real);

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -41,6 +41,7 @@ pub(crate) enum CargoCacheCommands<'a> {
     },
     //Debug,
     Version,
+    Verify,
     Query {
         query_config: &'a ArgMatches,
     }, // subcommand
@@ -169,6 +170,8 @@ pub(crate) fn clap_to_enum(config: &ArgMatches) -> CargoCacheCommands<'_> {
             arg_younger: config.value_of("remove-if-older-than"),
             dirs: config.value_of("remove-dir"),
         }
+    } else if let Some(_verify_cfg) = config.subcommand_matches("verify") {
+        CargoCacheCommands::Verify
     } else if dry_run {
         // none of the flags that do on-disk changes are present
 
@@ -368,6 +371,9 @@ pub(crate) fn gen_clap() -> ArgMatches {
 
     // </trim>
     let toolchain = App::new("toolchain").about("print stats on installed toolchains");
+
+    let verify = App::new("verifify").about("verify crate sources");
+
     // now thread all of these together
 
     // subcommand hack to have "cargo cache --foo" and "cargo-cache --foo" work equally
@@ -392,6 +398,7 @@ pub(crate) fn gen_clap() -> ArgMatches {
         .subcommand(clean_unref.clone())
         .subcommand(toolchain.clone())
         .subcommand(trim.clone())
+        .subcommand(verify.clone())
         .arg(&list_dirs)
         .arg(&remove_dir)
         .arg(&gc_repos)
@@ -426,6 +433,7 @@ pub(crate) fn gen_clap() -> ArgMatches {
         .subcommand(clean_unref)
         .subcommand(toolchain.clone())
         .subcommand(trim)
+        .subcommand(verify)
         .arg(&list_dirs)
         .arg(&remove_dir)
         .arg(&gc_repos)

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -372,7 +372,7 @@ pub(crate) fn gen_clap() -> ArgMatches {
     // </trim>
     let toolchain = App::new("toolchain").about("print stats on installed toolchains");
 
-    let verify = App::new("verifify").about("verify crate sources");
+    let verify = App::new("verify").about("verify crate sources");
 
     // now thread all of these together
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -174,11 +174,11 @@ pub(crate) fn clap_to_enum(config: &ArgMatches) -> CargoCacheCommands<'_> {
             dirs: config.value_of("remove-dir"),
         }
     } else if let Some(verify_cfg) = config.subcommand_matches("verify") {
-        let dry_run: bool = verify_cfg.is_present("dry-run");
+        let dry_run2: bool = verify_cfg.is_present("dry-run") || config.is_present("dry-run");
         let clean_corrupted: bool = verify_cfg.is_present("clean-corrupted");
         CargoCacheCommands::Verify {
             clean_corrupted,
-            dry_run,
+            dry_run: dry_run2,
         }
     } else if dry_run {
         // none of the flags that do on-disk changes are present

--- a/src/main.rs
+++ b/src/main.rs
@@ -89,7 +89,7 @@ cfg_if::cfg_if! {
         use crate::top_items_summary::*;
         use crate::clean_unref::*;
         use crate::cli::{CargoCacheCommands};
-        use crate::verify::*;
+        //use crate::verify;
     }
 }
 
@@ -469,9 +469,12 @@ fn main() {
                 eprintln!("Warning: there is nothing to be dry run!");
             }
         }
-        CargoCacheCommands::Verify => {
+        CargoCacheCommands::Verify {
+            clean_corrupted,
+            dry_run,
+        } => {
             println!("Verifying cache, this may take some time...\n");
-            if let Err(failed_verifications) = verify_crates(&mut registry_sources_caches) {
+            if let Err(failed_verifications) = verify::verify_crates(&mut registry_sources_caches) {
                 eprintln!("\n");
                 failed_verifications
                     .iter()
@@ -480,6 +483,15 @@ fn main() {
                     "\nFound {} possible corrupted sources.",
                     failed_verifications.len()
                 );
+
+                if clean_corrupted {
+                    verify::clean_corrupted(
+                        &mut registry_sources_caches,
+                        &failed_verifications,
+                        dry_run,
+                    );
+                }
+
                 std::process::exit(1)
             } else {
                 std::process::exit(0);

--- a/src/main.rs
+++ b/src/main.rs
@@ -470,8 +470,15 @@ fn main() {
             }
         }
         CargoCacheCommands::Verify => {
-            verify_crates(&mut registry_sources_caches).expect("verification failed :(");
-            std::process::exit(0);
+            if let Err(failed_verifications) = verify_crates(&mut registry_sources_caches) {
+                eprintln!("Error: some crate sources might be corrupted!\n");
+                failed_verifications
+                    .iter()
+                    .for_each(|diff| println!("{}", diff.details()));
+                std::process::exit(1)
+            } else {
+                std::process::exit(0);
+            }
         }
         _ => (),
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -470,11 +470,16 @@ fn main() {
             }
         }
         CargoCacheCommands::Verify => {
+            println!("Verifying cache, this may take some time...\n");
             if let Err(failed_verifications) = verify_crates(&mut registry_sources_caches) {
-                eprintln!("Error: some crate sources might be corrupted!\n");
+                eprintln!("\n");
                 failed_verifications
                     .iter()
                     .for_each(|diff| println!("{}", diff.details()));
+                eprintln!(
+                    "\nFound {} possible corrupted sources.",
+                    failed_verifications.len()
+                );
                 std::process::exit(1)
             } else {
                 std::process::exit(0);

--- a/src/main.rs
+++ b/src/main.rs
@@ -490,6 +490,8 @@ fn main() {
                         &failed_verifications,
                         dry_run,
                     );
+                } else {
+                    println!("Hint: use `cargo cache verify --clean-corrupted` to remove them.");
                 }
 
                 std::process::exit(1)

--- a/src/main.rs
+++ b/src/main.rs
@@ -470,7 +470,7 @@ fn main() {
             }
         }
         CargoCacheCommands::Verify => {
-            verify::verify_crates(&mut registry_pkgs_cache, &mut registry_sources_caches);
+            verify_crates(&mut registry_sources_caches).expect("verification failed :(");
             std::process::exit(0);
         }
         _ => (),

--- a/src/main.rs
+++ b/src/main.rs
@@ -470,7 +470,7 @@ fn main() {
             }
         }
         CargoCacheCommands::Verify => {
-            verify::verify_crates();
+            verify::verify_crates(&mut registry_pkgs_cache, &mut registry_sources_caches);
             std::process::exit(0);
         }
         _ => (),

--- a/src/main.rs
+++ b/src/main.rs
@@ -74,6 +74,7 @@ cfg_if::cfg_if! {
         mod top_items_summary;
         mod date;
         mod clean_unref;
+        mod verify;
 
         // use
         use crate::cache::caches::{Cache, RegistrySuperCache};
@@ -88,6 +89,7 @@ cfg_if::cfg_if! {
         use crate::top_items_summary::*;
         use crate::clean_unref::*;
         use crate::cli::{CargoCacheCommands};
+        use crate::verify::*;
     }
 }
 
@@ -466,6 +468,10 @@ fn main() {
             if !size_changed {
                 eprintln!("Warning: there is nothing to be dry run!");
             }
+        }
+        CargoCacheCommands::Verify => {
+            verify::verify_crates();
+            std::process::exit(0);
         }
         _ => (),
     }

--- a/src/verify.rs
+++ b/src/verify.rs
@@ -51,7 +51,14 @@ pub(crate) struct Diff {
     krate_name: String,
     files_missing_in_checkout: Vec<PathBuf>,
     additional_files_in_checkout: Vec<PathBuf>,
-    files_size_difference: Vec<PathBuf>,
+    files_size_difference: Vec<FileSizeDifference>,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct FileSizeDifference {
+    path: PathBuf,
+    size_archive: u64,
+    size_source: u64,
 }
 
 impl Diff {
@@ -165,7 +172,11 @@ pub(crate) fn verify_crates(
                     {
                         Some(fws) => {
                             if fws.size != archive_file.size {
-                                diff.files_size_difference.push(fws.path.clone());
+                                diff.files_size_difference.push(FileSizeDifference {
+                                    path: fws.path.clone(),
+                                    size_archive: archive_file.size,
+                                    size_source: fws.size,
+                                });
                             }
                         }
                         None => unreachable!(), // we already checked this

--- a/src/verify.rs
+++ b/src/verify.rs
@@ -284,3 +284,23 @@ pub(crate) fn clean_corrupted(
     // just in case
     registry_sources_caches.invalidate();
 }
+
+#[cfg(test)]
+mod verification_tests {
+    use super::*;
+    use pretty_assertions::assert_eq;
+
+    #[test]
+    fn test_map_src_path_to_cache_path() {
+        let old_src_path = PathBuf::from(
+            "/home/matthias/.cargo/registry/src/github.com-1ecc6299db9ec823/bytes-0.4.12",
+        );
+        let new_archive_path = PathBuf::from(
+            "/home/matthias/.cargo/registry/cache/github.com-1ecc6299db9ec823/bytes-0.4.12.crate",
+        );
+
+        let new = map_src_path_to_cache_path(&old_src_path);
+
+        assert_eq!(new, new_archive_path);
+    }
+}

--- a/src/verify.rs
+++ b/src/verify.rs
@@ -1,12 +1,38 @@
 use crate::cache::caches::Cache;
 use crate::cache::caches::RegistrySubCache;
 use crate::cache::caches::RegistrySuperCache;
-
 use crate::cache::*;
 use crate::library::*;
+
+use flate2::read::GzDecoder;
+use tar::Archive;
+
 use std::ffi::{OsStr, OsString};
+use std::fs::File;
 use std::path::PathBuf;
 
+#[derive(Debug, Clone)]
+struct FileWithSize {
+    path: PathBuf,
+    size: u64,
+}
+
+impl FileWithSize {
+    fn from_disk(path: &PathBuf) -> Self {
+        FileWithSize {
+            path: path.clone(),
+            size: std::fs::metadata(path).unwrap().len(),
+        }
+    }
+
+    // TODO: understand this R: Read stuff
+    fn from_archive<'a, R: std::io::Read>(entry: &tar::Entry<'a, R>) -> Self {
+        FileWithSize {
+            path: entry.path().unwrap().into_owned(),
+            size: entry.size(),
+        }
+    }
+}
 pub(crate) fn verify_crates(
     registry_pkg_caches: &mut registry_pkg_cache::RegistryPkgCaches,
     registry_sources_caches: &mut registry_sources::RegistrySourceCaches,
@@ -48,7 +74,38 @@ pub(crate) fn verify_crates(
     // this would fail if we for example have a crate source dir but no corresponding archive
     assert_eq!(crate_gzips_and_sources.len(), reg_sources.len());
 
-    crate_gzips_and_sources.iter().map(|(source, krate)| {});
+    crate_gzips_and_sources
+        .iter()
+        .map(|(source, krate)| {
+            let files_of_archive = {
+                let tar_gz = File::open(krate).unwrap();
+                // extract the tar
+                let tar = GzDecoder::new(tar_gz);
+                let mut archive = Archive::new(tar);
+
+                let archive_files = archive.entries().unwrap();
+
+                let x: Vec<_> = archive_files
+                    .into_iter()
+                    .map(|entry| {
+                        let e = entry.unwrap();
+                        e.path().unwrap().into_owned()
+                    })
+                    .collect();
+                x
+            };
+
+            let files_of_source: Vec<_> = std::fs::read_dir(source)
+                .unwrap()
+                .map(|direntry| {
+                    let x = direntry.unwrap();
+                    x.path()
+                })
+                .collect();
+
+            println!("{:?}|||||{:?}", files_of_archive, files_of_source);
+        })
+        .collect::<Vec<_>>();
 
     if false {
         return Err(());

--- a/src/verify.rs
+++ b/src/verify.rs
@@ -221,6 +221,7 @@ fn diff_crate_and_source(krate: &Path, source: &Path) -> Diff {
         .filter(|path| !path.is_dir() /* skip dirs */)
     {
         // dbg!(source_file);
+        #[allow(clippy::implicit_clone)]
         if !files_of_archive.iter().any(|path| path == source_file) {
             diff.additional_files_in_checkout
                 .push(source_file.to_path_buf());

--- a/src/verify.rs
+++ b/src/verify.rs
@@ -13,8 +13,8 @@ pub(crate) fn verify_crates(
 ) -> Result<(), ()> {
     // iterate over all the extracted sources that we have
 
-    let crate_gzips_and_sources: Vec<_> = registry_sources_caches
-        .items()
+    let reg_sources = registry_sources_caches.items();
+    let crate_gzips_and_sources: Vec<_> = reg_sources
         .iter()
         .map(|source| {
             // for each directory, find the path to the corresponding .crate archive
@@ -39,17 +39,16 @@ pub(crate) fn verify_crates(
 
             dir.push(&comp1_with_crate_ext); // bytes-0.4.12.crate
             let krate: PathBuf = dir.into_iter().collect::<PathBuf>();
-            dbg!((source, krate))
+            (source, krate)
         })
         // we need both the .crate and the directory for verification
         .filter(|(source, krate)| source.exists() && krate.exists())
         .collect();
 
     // this would fail if we for example have a crate source dir but no corresponding archive
-    assert_eq!(
-        crate_gzips_and_sources.len(),
-        registry_sources_caches.items().len()
-    );
+    assert_eq!(crate_gzips_and_sources.len(), reg_sources.len());
+
+    crate_gzips_and_sources.iter().map(|(source, krate)| {});
 
     if false {
         return Err(());

--- a/src/verify.rs
+++ b/src/verify.rs
@@ -274,7 +274,7 @@ pub(crate) fn clean_corrupted(
                 path,
                 dry_run,
                 &mut bool,
-                Some(format!("removing corrupted source: {}", path.display())), //TODO add msg here
+                Some(format!("removing corrupted source: {}", path.display())),
                 &crate::remove::DryRunMessage::Default,
                 // we don't print a summary or anything (yet..)
                 None,

--- a/src/verify.rs
+++ b/src/verify.rs
@@ -44,6 +44,14 @@ impl FileWithSize {
     }
 }
 
+/// Size difference of a file in the .gz archive and extracted source
+#[derive(Debug, Clone)]
+pub(crate) struct FileSizeDifference {
+    path: PathBuf,
+    size_archive: u64,
+    size_source: u64,
+}
+
 /// The Difference between extracted crate sources and an .crate tar.gz archive
 #[derive(Debug, Clone)]
 pub(crate) struct Diff {
@@ -52,13 +60,6 @@ pub(crate) struct Diff {
     files_missing_in_checkout: Vec<PathBuf>,
     additional_files_in_checkout: Vec<PathBuf>,
     files_size_difference: Vec<FileSizeDifference>,
-}
-
-#[derive(Debug, Clone)]
-pub(crate) struct FileSizeDifference {
-    path: PathBuf,
-    size_archive: u64,
-    size_source: u64,
 }
 
 impl Diff {

--- a/src/verify.rs
+++ b/src/verify.rs
@@ -1,0 +1,58 @@
+use crate::cache::caches::Cache;
+use crate::cache::caches::RegistrySubCache;
+use crate::cache::caches::RegistrySuperCache;
+
+use crate::cache::*;
+use crate::library::*;
+use std::ffi::{OsStr, OsString};
+use std::path::PathBuf;
+
+pub(crate) fn verify_crates(
+    registry_pkg_caches: &mut registry_pkg_cache::RegistryPkgCaches,
+    registry_sources_caches: &mut registry_sources::RegistrySourceCaches,
+) -> Result<(), ()> {
+    // iterate over all the extracted sources that we have
+
+    let crate_gzips_and_sources: Vec<_> = registry_sources_caches
+        .items()
+        .iter()
+        .map(|source| {
+            // for each directory, find the path to the corresponding .crate archive
+            // .cargo/registry/src/github.com-1ecc6299db9ec823/bytes-0.4.12
+            // corresponds to
+            // .cargo/registry/cache/github.com-1ecc6299db9ec823/bytes-0.4.12.crate
+
+            // reverse, and "pop" the front components
+            let mut dir = source.iter().collect::<Vec<&OsStr>>();
+
+            let comp1 = dir.pop().unwrap(); // /bytes-0.4.12
+            let comp2 = dir.pop().unwrap(); // github.com-1ecc6299db9ec823
+            let _src = dir.pop().unwrap(); // throw this away and add "cache" instead
+
+            // reconstruct the fixed path in reverse order
+
+            dir.push(OsStr::new("cache"));
+            dir.push(comp2); // github.com...
+                             // we need to add the .crate extension (path to the gzip archive)
+            let mut comp1_with_crate_ext = comp1.to_os_string();
+            comp1_with_crate_ext.push(".crate");
+
+            dir.push(&comp1_with_crate_ext); // bytes-0.4.12.crate
+            let krate: PathBuf = dir.into_iter().collect::<PathBuf>();
+            dbg!((source, krate))
+        })
+        // we need both the .crate and the directory for verification
+        .filter(|(source, krate)| source.exists() && krate.exists())
+        .collect();
+
+    // this would fail if we for example have a crate source dir but no corresponding archive
+    assert_eq!(
+        crate_gzips_and_sources.len(),
+        registry_sources_caches.items().len()
+    );
+
+    if false {
+        return Err(());
+    }
+    Ok(())
+}

--- a/src/verify.rs
+++ b/src/verify.rs
@@ -79,26 +79,34 @@ impl Diff {
     }
 
     pub(crate) fn details(&self) -> String {
-        let mut s = format!("Crate: {}", self.krate_name);
+        let mut s = format!("Crate: {}\n", self.krate_name);
         if !self.files_missing_in_checkout.is_empty() {
             s.push_str(&format!(
-                "missing files:\n{:#?}",
+                "\nmissing files:\n{}",
                 self.files_missing_in_checkout
+                    .iter()
+                    .map(|path| path.display().to_string())
+                    .collect::<Vec<String>>()
+                    .join(", ")
             ));
         }
         if !self.additional_files_in_checkout.is_empty() {
             s.push_str(&format!(
-                "additional files:\n{:#?}",
+                "\nadditional files:\n{}",
                 self.additional_files_in_checkout
+                    .iter()
+                    .map(|path| path.display().to_string())
+                    .collect::<Vec<String>>()
+                    .join(", ")
             ));
         }
         if !self.files_size_difference.is_empty() {
-            s.push_str("Files with differing size:");
+            s.push_str("\nFiles with differing size:\n");
             self.files_size_difference
                 .iter()
                 .map(|fsd| {
                     format!(
-                        "File: {}, size in archive: {}, size in checkout: {}",
+                        "File: {}, size in archive: {}b, size in checkout: {}b\n",
                         fsd.path.display(),
                         fsd.size_archive,
                         fsd.size_source

--- a/src/verify.rs
+++ b/src/verify.rs
@@ -6,6 +6,7 @@ use crate::cache::caches::RegistrySuperCache;
 use crate::cache::*;
 
 use flate2::read::GzDecoder;
+use rayon::iter::*;
 use tar::Archive;
 use walkdir::WalkDir;
 
@@ -77,7 +78,7 @@ pub(crate) fn verify_crates(
 
     let reg_sources = registry_sources_caches.items();
     let bad_sources: Vec<_> = reg_sources
-        .iter()
+        .par_iter()
         // get the paths to the source and the .crate for all extracted crates
         .map(|source| {
             // for each directory, find the path to the corresponding .crate archive

--- a/src/verify.rs
+++ b/src/verify.rs
@@ -18,15 +18,13 @@ struct FileWithSize {
 }
 
 impl FileWithSize {
-    fn from_disk(path_orig: &Path) -> Self {
+    fn from_disk(path_orig: &Path, krate_root: &OsStr) -> Self {
         // we need to cut off .cargo/registry/src/github.com-1ecc6299db9ec823/
         let index = path_orig
             .iter()
             .enumerate()
-            .position(|e| e.1 == OsStr::new("github.com-1ecc6299db9ec823").to_os_string())
-            // @TODO fix this to be dynamic
-            .unwrap()
-            + 1;
+            .position(|e| e.1 == krate_root.to_os_string())
+            .unwrap();
 
         let path = path_orig.iter().skip(index).collect::<PathBuf>();
 
@@ -169,6 +167,7 @@ fn sizes_of_archive_files(path: &PathBuf) -> Vec<FileWithSize> {
 
 /// get the files and their sizes of the extracted .crate sources
 fn sizes_of_src_dir(source: &PathBuf) -> Vec<FileWithSize> {
+    let krate_root = source.iter().last().unwrap();
     WalkDir::new(source)
         .into_iter()
         .map(Result::unwrap)
@@ -178,7 +177,7 @@ fn sizes_of_src_dir(source: &PathBuf) -> Vec<FileWithSize> {
             let p = direntry.path();
             p.to_owned()
         })
-        .map(|p| FileWithSize::from_disk(&p))
+        .map(|p| FileWithSize::from_disk(&p, &krate_root))
         .collect()
 }
 

--- a/src/verify.rs
+++ b/src/verify.rs
@@ -83,26 +83,27 @@ impl Diff {
         let mut s = format!("Crate: {}\n", self.krate_name);
         if !self.files_missing_in_checkout.is_empty() {
             s.push_str(&format!(
-                "\nmissing files:\n{}",
+                "Missing from source:\n{}",
                 self.files_missing_in_checkout
                     .iter()
                     .map(|path| path.display().to_string())
                     .collect::<Vec<String>>()
                     .join(", ")
             ));
+            s.push('\n');
         }
         if !self.additional_files_in_checkout.is_empty() {
             s.push_str(&format!(
-                "\nadditional files:\n{}",
+                "Not found in archive/additional:\n{}",
                 self.additional_files_in_checkout
                     .iter()
                     .map(|path| path.display().to_string())
                     .collect::<Vec<String>>()
                     .join(", ")
             ));
+            s.push('\n');
         }
         if !self.files_size_difference.is_empty() {
-            s.push_str("\nFiles with differing size:\n");
             self.files_size_difference
                 .iter()
                 .map(|fsd| {
@@ -114,7 +115,7 @@ impl Diff {
                     )
                 })
                 .for_each(|strg| s.push_str(&strg));
-            s.push('\n');
+            //s.push('\n');
         }
         s
     }

--- a/src/verify.rs
+++ b/src/verify.rs
@@ -119,47 +119,44 @@ impl Diff {
         s
     }
 }
+
+/// take a path to an extracted .crate source and map it to the corresponding .carte archive path
+fn map_src_path_to_cache_path(src_path: &PathBuf) -> PathBuf {
+    // for each directory, find the path to the corresponding .crate archive
+    // .cargo/registry/src/github.com-1ecc6299db9ec823/bytes-0.4.12
+    // corresponds to
+    // .cargo/registry/cache/github.com-1ecc6299db9ec823/bytes-0.4.12.crate
+
+    // reverse, and "pop" the front components
+    let mut dir = src_path.iter().collect::<Vec<&OsStr>>();
+
+    let comp1 = dir.pop().unwrap(); // /bytes-0.4.12
+    let comp2 = dir.pop().unwrap(); // github.com-1ecc6299db9ec823
+    let _src = dir.pop().unwrap(); // throw this away and add "cache" instead
+
+    // reconstruct the fixed path in reverse order
+
+    dir.push(OsStr::new("cache"));
+    dir.push(comp2); // github.com...
+                     // we need to add the .crate extension (path to the gzip archive)
+    let mut comp1_with_crate_ext = comp1.to_os_string();
+    comp1_with_crate_ext.push(".crate");
+
+    dir.push(&comp1_with_crate_ext); // bytes-0.4.12.crate
+    dir.into_iter().collect::<PathBuf>()
+}
 pub(crate) fn verify_crates(
     registry_sources_caches: &mut registry_sources::RegistrySourceCaches,
 ) -> Result<(), Vec<Diff>> {
     // iterate over all the extracted sources that we have
 
-    let reg_sources = registry_sources_caches.items();
-    let bad_sources: Vec<_> = reg_sources
+    let bad_sources: Vec<_> = registry_sources_caches
+        .items()
         .par_iter()
         // get the paths to the source and the .crate for all extracted crates
-        .map(|source| {
-            // for each directory, find the path to the corresponding .crate archive
-            // .cargo/registry/src/github.com-1ecc6299db9ec823/bytes-0.4.12
-            // corresponds to
-            // .cargo/registry/cache/github.com-1ecc6299db9ec823/bytes-0.4.12.crate
-
-            // reverse, and "pop" the front components
-            let mut dir = source.iter().collect::<Vec<&OsStr>>();
-
-            let comp1 = dir.pop().unwrap(); // /bytes-0.4.12
-            let comp2 = dir.pop().unwrap(); // github.com-1ecc6299db9ec823
-            let _src = dir.pop().unwrap(); // throw this away and add "cache" instead
-
-            // reconstruct the fixed path in reverse order
-
-            dir.push(OsStr::new("cache"));
-            dir.push(comp2); // github.com...
-                             // we need to add the .crate extension (path to the gzip archive)
-            let mut comp1_with_crate_ext = comp1.to_os_string();
-            comp1_with_crate_ext.push(".crate");
-
-            dir.push(&comp1_with_crate_ext); // bytes-0.4.12.crate
-            let krate: PathBuf = dir.into_iter().collect::<PathBuf>();
-            (source, krate)
-        })
-        // we need both the .crate and the directory for verification
+        .map(|source| (source, map_src_path_to_cache_path(source)))
+        // we need both the .crate and the directory to exist for verification
         .filter(|(source, krate)| source.exists() && krate.exists())
-        //  .collect();
-        // this would fail if we for example have a crate source dir but no corresponding archive
-        //  assert_eq!(crate_gzips_and_sources.len(), reg_sources.len());
-        //let _x = crate_gzips_and_sources
-        //  .iter()
         .map(|(source, krate)| {
             let krate_name = source.iter().last().unwrap();
             //println!("Verifying: {}", &krate_name.to_str().unwrap());

--- a/tests/clean_unref.rs
+++ b/tests/clean_unref.rs
@@ -162,7 +162,7 @@ fn test_clean_unref() {
     let mut desired_output = String::from("Cargo cache .*clean_unref_CARGO_HOME.*:\n\n");
     desired_output.push_str(
         "Total:                          .* MB
-  0 installed binaries:              0  B
+  0 installed binaries:       .* 0  B
   Registry:                     .* MB
     Registry index:             .* MB
     1 crate archives:           .* KB


### PR DESCRIPTION
this will try to verify checked out sources against .crate archives and warn if sizes of files differ, in case there have been some modifications to local extracted crates.