### PR TITLE
fix: 'verify' can handle equivalency of paths with different unicode representations (#113)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -80,6 +80,7 @@ dependencies = [
  "rustc_tools_util",
  "tar",
  "tempfile",
+ "unicode-normalization",
  "walkdir",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,6 +63,8 @@ rustc_tools_util = { version = "0.2.0", optional = true } # git version informat
 # https://github.com/alexcrichton/tar-rs
 tar = { version = "0.4.38", optional = true } # extract tars
 
+unicode-normalization = { version = "0.1.19" } # handle nfc paths
+
 # https://github.com/BurntSushi/walkdir
 walkdir = { version = "2.3.1", optional = true } # walk content of directory/CARGO_HOME recursively
 


### PR DESCRIPTION
This fixes issue #113 which explains the problem in greater detail.

It's unclear if this now works for all the representations out there, or only a few ones.