### PR TITLE
clean-unref docs clarification

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Display information on the cargo cache (`~/.cargo/` or `$CARGO_HOME`). Optional 
 * alternative registries supported
 * remove files older or younger than X (`--remove-if-{older,younger}-than`)
 * builds and runs on `stable`, `beta` and `nightly` channel
-* purge cache entries not unused to build a specified crate (`cargo cache clean-unref`)
+* purge cache entries not used to build a specified crate (`cargo cache clean-unref`)
 * print size stats on a local sccache build cache  (`cargo cache sc`)
 * verify extracted crate sources (`cargo cache verify`)
 


### PR DESCRIPTION
Hi Matthias and contributors,

Thank you for `cargo-cache`. The current wording for `clean-unref` in README.md uses a double/triple negative, probably a typo. This PR makes it similar to:
```bash
cargo cache clean-unref --help
cargo-cache-clean-unref 
remove crates that are not referenced in a Cargo.toml from the cache
```

(Tangential to issue # 116.)